### PR TITLE
Set github actions timeout to 45 min

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -18,7 +18,7 @@ jobs:
   build:
     name: ${{ matrix.tox_env }}
     runs-on: ubuntu-20.04
-    timeout-minutes: 30
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Helps again flakiness since job sometimes need to run 3 times before VM starts OK.