### PR TITLE
enable tox wordkir supercharge

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,8 @@ envlist =
     py{36,37,38,39}-{ansible_2,ansible_3,ansible_4}
     py{36,37,38,39}-{ansible_2,ansible_3,ansible_4}-{devel}
 
+toxworkdir={env:TOX_WORK_DIR:.tox}
+
 # do not enable skip missing to avoid CI false positives
 skip_missing_interpreters = False
 isolated_build = True


### PR DESCRIPTION
Usefull when want to keep workdir cached for faster tests