### PR TITLE
Feat/alternative endpoint

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,11 +42,6 @@ variables in your ``molecule.yml``. Here's a simple example using a home made ce
     - name: instance
       image: quay.io/kubevirt/fedora-cloud-container-disk-demo
 
-This driver also requires molecule to access Kubernetes API. See test-rolebinding_ file.
-
-.. _`test-rolebinding`: /tools/test-rolebinding.yaml
-
-
 Installation
 ============
 
@@ -70,6 +65,69 @@ KubeVirt
 
 Get access to a Kubernetes cluster then install KubeVirt for `kind <https://kubevirt.io/quickstart_kind/>`_ or `minkube <https://kubevirt.io/quickstart_minikube/>`_ or `cloud providers <https://kubevirt.io/quickstart_cloud/>`_
 
+
+SSH access
+==========
+
+A Kubernetes Service is created by the driver for SSH access. Current supported Services are ClusterIP and NodePort.
+
+ClusterIP
+---------
+
+Default SSH Service is ClusterIP and a static clusterIP can be set:
+
+.. code-block:: yaml
+
+  ssh_service:
+    type: ClusterIP
+    clusterIP: 10.96.102.231
+
+Please note molecule needs to be able to route ip to ClusterIPs Services:
+
+* if running Kubernetes with kind:
+
+.. code-block:: shell
+
+  IP=$(docker container inspect kind-control-plane   --format '{{ .NetworkSettings.Networks.kind.IPAddress }}')
+  sudo ip route add 10.96.0.0/12 via $IP # Linux
+  # sudo route -n add 10.96.0.0/12 $IP # MacOSX
+
+* if running Kubernetes with minikube:
+
+.. code-block:: shell
+
+  sudo ip route add 172.17.0.0/16 via $(minikube ip) # Linux
+  # sudo route -n add 172.17.0.0/16 $(minikube ip) # MacOSX
+
+If running tox from inside Kubernetes cluster, nothing to do on this item.
+
+
+NodePort
+--------
+
+NodePort can be set. Static nodePort can be defined, also host target for port can be set:
+
+.. code-block:: yaml
+
+  ssh_service:
+    type: NodePort
+    # optional static port
+    nodePort: 32569
+    # host where nodePort can be reached
+    nodePort_host: localhost
+
+
+Run from inside Kubernetes cluster
+==================================
+
+You can run this driver with a container running tox and/or molecule. Take a look at:
+ * Dockerfile_ as a base image
+ * test-rolebinding_ file for ServiceAccount example
+ * github_workflow_ in step named "Launch test" for a Kubernetes Job running tox
+
+.. _`test-rolebinding`: /tools/test-rolebinding.yaml
+.. _`Dockerfile`: /tools/Dockerfile
+.. _`github_workflow`: .github/workflows/tox.yml
 
 Demo
 ====

--- a/molecule_kubevirt/driver.py
+++ b/molecule_kubevirt/driver.py
@@ -59,12 +59,17 @@ class KubeVirt(Driver):
             cpu_shares: (omit)
             ephemeral: (omit)
             image: image_name:tag
+        ssh_service:
+            type: ClusterIP
+            clusterIP: {}
+            nodePort: {}
+            nodePort_host: localhost
 
     Image MUST be accessible on Kubernetes workers running Kubevirt. This driver
     provides no service for building images. Solutions using CDI may be found in
     later version .
 
-    Minimal authorizations are required for the molecule runner, via ServiceAccount :
+    Minimal authorizations are required for the molecule runner if running from Kubernetes, via ServiceAccount :
     .. code-block::yaml
         roleRef:
           apiGroup: rbac.authorization.k8s.io

--- a/molecule_kubevirt/playbooks/create.yml
+++ b/molecule_kubevirt/playbooks/create.yml
@@ -14,6 +14,7 @@
     default_vm_machine_type: "q35"
     default_vm_disk_image: "quay.io/kubevirt/fedora-cloud-container-disk-demo"
     default_ssh_timeout: 300
+    default_ssh_service_type: ClusterIP
     ssh_key_path: "{{ molecule_ephemeral_directory }}/identity_{{ item.name }}"
 
   tasks:
@@ -90,14 +91,44 @@
                 imagePullPolicy: "IfNotPresent"
             disk:
               bus: virtio
-      loop: "{{ molecule_yml.platforms  }}"
+      loop: "{{ molecule_yml.platforms }}"
       loop_control:
         label: "{{ item.name }}"
       async: "{{ item.wait_timeout | default(default_vm_timeout) }}"
       poll: 0
       register: poll_reg
 
-    - name: Create ssh service
+    - name: Create ssh NodePort Kubernetes Services
+      when: "item.ssh_service.type | default(default_ssh_service_type) == 'NodePort'"
+      k8s:
+        state: present
+        definition:
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: "{{ item.name }}"
+            namespace: "{{ item.namespace | default(default_namespace) }}"
+          spec: "{{ spec | from_yaml }}"
+      register: node_port_services
+      loop: "{{ molecule_yml.platforms  }}"
+      loop_control:
+        label: "{{ item.name }}"
+      # workaround https://stackoverflow.com/questions/63961938/ansible-variable-conversion-to-int-is-ignored
+      vars:
+        spec: |-
+          ports:
+            - port: 22
+              protocol: TCP
+              targetPort: 22
+              {%- if item.ssh_service.nodePort | default(None) +%}
+              nodePort: {{ item.ssh_service.nodePort | int }}
+              {%- endif +%}
+          selector:
+            vm.cnv.io/name: "{{ item.name }}"
+          type: NodePort
+
+    - name: Create ssh ClusterIP Kubernetes Services
+      when: "item.ssh_service.type | default(default_ssh_service_type) == 'ClusterIP'"
       k8s:
         state: present
         definition:
@@ -107,6 +138,7 @@
             name: "{{ item.name }}"
             namespace: "{{ item.namespace | default(default_namespace) }}"
           spec:
+            clusterIP: "{{ item.ssh_service.clusterIP | default(omit) }}"
             ports:
               - port: 22
                 protocol: TCP
@@ -114,7 +146,7 @@
             selector:
               vm.cnv.io/name: "{{ item.name }}"
             type: ClusterIP
-      register: service
+      register: cluster_ip_services
       loop: "{{ molecule_yml.platforms  }}"
       loop_control:
         label: "{{ item.name }}"
@@ -146,50 +178,74 @@
           fail:
             msg: "{{ vm_info }}"
 
-    - name: Populate instance config dict
-      set_fact:
-        instance_conf_dict: |
-          { "instance": "{{ item.kubevirt_vm.metadata.name }}",
-            "address": "{{ item.kubevirt_vm.metadata.name }}.{{ item.kubevirt_vm.metadata.namespace }}.svc",
-            "user": "{{ item.user_name | default(default_user_name) }}",
-            "port": "22",
-            "identity_file": "{{ molecule_ephemeral_directory }}/identity_{{ item.kubevirt_vm.metadata.name }}"
-          }
-      loop: "{{ async_poll_results.results }}"
-      loop_control:
-        label: "{{ item.kubevirt_vm.metadata.name }}"
-      register: instance_config_dict
+    - name: SSH check block
+      block:
+        - name: Get ssh services info, indexed by service name
+          set_fact:
+            service_instance: >-
+              {{ service_instance|default({}) | combine({svc_name: svc_spec}) }}
+          loop: "{{ loop_services | flatten }}"
+          loop_control:
+            label: "{{ {svc_name: svc_spec } }}"
+          vars:
+            loop_services:
+              - "{{ cluster_ip_services.results | rejectattr('skipped', 'true') }}"
+              - "{{ node_port_services.results| rejectattr('skipped', 'true') }}"
+            svc_name: "{{ item.result.metadata.name }}"
+            svc_spec: "{{ item.result.spec }}"
 
-    - name: Convert instance config dict to a list
-      set_fact:
-        instance_conf: "{{ instance_config_dict.results | map(attribute='ansible_facts.instance_conf_dict') | list }}"
+        - name: Populate instance config dict
+          set_fact:
+            instance_conf_dict:
+              instance: "{{ item.name }}"
+              address: "{{ ssh_service_address }}"
+              user: "{{ item.user_name | default('molecule') }}"
+              port: "22"
+              identity_file: "{{ molecule_ephemeral_directory }}/identity_{{ item.name }}"
+          vars:
+            # set target ssh address regarding platforms configuration
+            ssh_service_address: >-
+              {%- set svc_ep = item.ssh_service.type | default('ClusterIP') -%}
+              {%- if svc_ep == 'NodePort' -%}
+              {{ item.ssh_service.nodePort_host | default('localhost') }}:{{ service_instance[item.name].ports[item.ssh_service.nodePort_index | default(0)].nodePort }}
+              {%- elif svc_ep == 'ClusterIP' -%}
+              {{ service_instance[item.name].clusterIP }}
+              {%- endif -%}
+          register: instance_config_dict
+          loop: "{{ molecule_yml.platforms }}"
+          loop_control:
+            label: "{{ item.name  }}"
+
+        - name: Convert instance config dict to a list
+          set_fact:
+            instance_conf: "{{ instance_config_dict.results | map(attribute='ansible_facts.instance_conf_dict') | list }}"
+
+        - name: Async start ssh access test
+          wait_for:
+            timeout: "{{ item.ssh_timeout | default(default_ssh_timeout) }}"
+            port: "{{ item.port | default('22') }}"
+            host: "{{ item.address }}"
+            delay: 1
+          loop: "{{ instance_conf }}"
+          loop_control:
+            label: "{{ {item.instance: item.address} }}"
+          async: "{{ item.ssh_timeout | default(default_ssh_timeout) }}"
+          poll: 0
+          register: ssh_reg
+
+        - name: Check ssh access test
+          async_status:
+            jid: "{{ async_result_item.ansible_job_id }}"
+          loop: "{{ ssh_reg.results }}"
+          loop_control:
+            loop_var: "async_result_item"
+          register: async_poll_results
+          until: async_poll_results.finished
+          delay: 1
+          retries: "{{ item['ansible_facts']['instance_conf_dict']['ssh_timeout'] | default(default_ssh_timeout) }}"
 
     - name: Dump instance config
       copy:
         content: "{{ instance_conf | to_json | from_json | to_yaml }}"
         dest: "{{ molecule_instance_config }}"
         mode: 0600
-
-    - name: Async start ssh access test
-      wait_for:
-        timeout: "{{ item['ansible_facts']['instance_conf_dict']['ssh_timeout'] | default(default_ssh_timeout) }}"
-        port: "{{ item['ansible_facts']['instance_conf_dict']['port'] | default('22') }}"
-        host: "{{ item['ansible_facts']['instance_conf_dict']['address'] }}"
-        delay: 1
-      loop: "{{ instance_config_dict.results }}"
-      loop_control:
-        label: "{{ item['ansible_facts']['instance_conf_dict']['address'] }}"
-      async: "{{ item['ssh_timeout'] | default(default_ssh_timeout) }}"
-      poll: 0
-      register: ssh_reg
-
-    - name: Check ssh access test
-      async_status:
-        jid: "{{ async_result_item.ansible_job_id }}"
-      loop: "{{ ssh_reg.results }}"
-      loop_control:
-        loop_var: "async_result_item"
-      register: async_poll_results
-      until: async_poll_results.finished
-      delay: 1
-      retries: "{{ item['ansible_facts']['instance_conf_dict']['ssh_timeout'] | default(default_ssh_timeout) }}"

--- a/molecule_kubevirt/playbooks/destroy.yml
+++ b/molecule_kubevirt/playbooks/destroy.yml
@@ -30,7 +30,7 @@
       k8s:
         state: absent
         kind: Service
-        name: "{{ item.name }}-ssh"
+        name: "{{ item.name }}"
         namespace: "{{ item.namespace | default('default') }}"
       loop: "{{ molecule_yml.platforms }}"
       loop_control:


### PR DESCRIPTION
Helps to use molecule on local dev machine:
* allow alternative ssh service as ClusterIP or NodePort plus some configuration

Also:
* remove support for service name as ssh endpoint (no use-case known)
* fix destroy ssh service
* refactor instance dict population