### PR TITLE
Feat/core.k8s

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,12 +50,11 @@ Ansible
 
 This driver supports Ansible 2, 3 and 4.
 
-Ansible 2 requires install of comunity.kubevirt plus strict python requirements pinning:
+Ansible 2 requires python requirements pinning to:
 
 .. code-block:: shell
 
-  ansible-galaxy install git+https://github.com/ansible-collections/community.general.git
-  python3 -m pip install openshift==0.11.2 kubernetes==11.0.0
+  python3 -m pip install 'openshift==0.11.*' 'kubernetes==11.*'
 
 **No depedency required for Ansible >= 3**
 

--- a/molecule_kubevirt/driver.py
+++ b/molecule_kubevirt/driver.py
@@ -53,11 +53,11 @@ class KubeVirt(Driver):
             cpu_cores: (omit)
             machine_type: q35
             cpu_model: (omit)
-            headless: (omit)
-            hugepage_size: (omit)
+            autoattachGraphicsDevice: false
+            memory_request: memory
+            cpu_request: (omit)
+            memory_limit: memory
             cpu_limit: (omit)
-            cpu_shares: (omit)
-            ephemeral: (omit)
             image: image_name:tag
         ssh_service:
             type: ClusterIP

--- a/molecule_kubevirt/playbooks/create.yml
+++ b/molecule_kubevirt/playbooks/create.yml
@@ -46,56 +46,70 @@
                   plain_text_passwd: molecule
                   lock_passwd: false
                   ssh_authorized_keys:
-                    - {{ lookup('file', molecule_ephemeral_directory + '/identity_'+ item.name + '.pub' ) }}
+                    - {{ lookup('file', ssh_key_path + '.pub' ) }}
       loop: "{{ molecule_yml.platforms  }}"
       loop_control:
         label: "{{ item.name }}"
 
-    - name: Async create virtual machine and start it
-      community.kubevirt.kubevirt_vm:
-        state: running
-        wait: true
-        wait_timeout: "{{ item.wait_timeout | default(default_vm_timeout) }}"
-        name: "{{ item.name }}"
-        namespace: "{{ item.namespace | default(default_namespace) }}"
-        memory: "{{ item.memory | default(default_vm_memory) }}"
-        cpu_cores: "{{ item.cpu_cores | default(omit) }}"
-        machine_type: "{{ item.machine_type | default(default_vm_machine_type) }}"
+    - name: Create virtual machines
+      vars:
+        container_disk_name: "{{ item.name }}"
 
-        interfaces:
-          - name: default
-            masquerade: {}
-            ports:
-              - port: 22
-            network:
-              pod: {}
-
-        cloud_init_nocloud:
-          secretRef:
-            name: "{{ item.name }}-cloud-init"
-
-        cpu_model: "{{ item.cpu_model | default(omit) }}"
-        headless: "{{ item.headless | default(omit) }}"
-        hugepage_size: "{{ item.hugepage_size | default(omit) }}"
-
-        cpu_limit: "{{ item.cpu_limit | default(omit) }}"
-        cpu_shares: "{{ item.cpu_shares | default(omit) }}"
-        ephemeral: "{{ item.ephemeral | default(omit) }}"
-
-        disks:
-          - name: "{{ item.name }}-container-disk"
-            volume:
-              containerDisk:
-                image: "{{ item.image | default(default_vm_disk_image) }}"
-                path: "{{ item.image_path | default(omit) }}"
-                imagePullPolicy: "IfNotPresent"
-            disk:
-              bus: virtio
+      k8s:
+        state: present
+        definition:
+          apiVersion: kubevirt.io/v1
+          kind: VirtualMachine
+          metadata:
+            name: "{{ item.name }}"
+            namespace: default
+          spec:
+            running: true
+            template:
+              metadata:
+                labels:
+                  vm.cnv.io/name: "{{ item.name }}"
+              spec:
+                domain:
+                  devices:
+                    autoattachGraphicsDevice: "{{ item.autoattachGraphicsDevice | default(false) }}"
+                    disks:
+                      - disk:
+                          bus: virtio
+                        name: "{{ container_disk_name }}"
+                      - disk:
+                          bus: virtio
+                        name: ansiblecloudinitdisk
+                    interfaces:
+                      - masquerade: {}
+                        name: default
+                        ports:
+                          - port: 22
+                  machine:
+                    type: "{{ item.machine_type | default(default_vm_machine_type) }}"
+                  resources:
+                    requests:
+                      memory: "{{ item.memory_request | default(item.memoy) | default(default_vm_memory) }}"
+                      cpu: "{{ item.cpu_request | default(item.cpu) | default(omit) }}"
+                    limits:
+                      memory: "{{ item.memory_limit | default(item.memoy) | default(default_vm_memory) }}"
+                      cpu: "{{ item.cpu_limit | default(item.cpu) | default(omit) }}"
+                networks:
+                  - name: default
+                    pod: {}
+                volumes:
+                  - containerDisk:
+                      image: "{{ item.image | default(default_vm_disk_image) }}"
+                      path: "{{ item.image_path | default(omit) }}"
+                      imagePullPolicy: "{{ item.image_pull_policy | default('IfNotPresent') }}"
+                    name: "{{ container_disk_name }}"
+                  - cloudInitNoCloud:
+                      secretRef:
+                        name: "{{ item.name }}-cloud-init"
+                    name: ansiblecloudinitdisk
       loop: "{{ molecule_yml.platforms }}"
       loop_control:
         label: "{{ item.name }}"
-      async: "{{ item.wait_timeout | default(default_vm_timeout) }}"
-      poll: 0
       register: poll_reg
 
     - name: Create ssh NodePort Kubernetes Services
@@ -150,33 +164,6 @@
       loop: "{{ molecule_yml.platforms  }}"
       loop_control:
         label: "{{ item.name }}"
-
-    - name: VM creation check block
-      block:
-        - name: Check VM creation status
-          async_status:
-            jid: "{{ async_result_item.ansible_job_id }}"
-          loop: "{{ poll_reg.results }}"
-          loop_control:
-            loop_var: "async_result_item"
-          register: async_poll_results
-          until: async_poll_results.finished
-          delay: 1
-          retries: "{{ default_vm_timeout }}"
-      rescue:
-        - name: Failed to get running VM - Get VM and VMI
-          k8s_info:
-            kind: "{{ item }}"
-            api_version: kubevirt.io/v1alpha3
-            namespace: "{{ item.namespace | default(default_namespace) }}"
-          with_items:
-            - VirtualMachine
-            - VirtualMachineInstance
-          register: vm_info
-
-        - name: Failed to get running VM - Dump VM and VMI
-          fail:
-            msg: "{{ vm_info }}"
 
     - name: SSH check block
       block:
@@ -233,16 +220,37 @@
           poll: 0
           register: ssh_reg
 
-        - name: Check ssh access test
-          async_status:
-            jid: "{{ async_result_item.ansible_job_id }}"
-          loop: "{{ ssh_reg.results }}"
-          loop_control:
-            loop_var: "async_result_item"
-          register: async_poll_results
-          until: async_poll_results.finished
-          delay: 1
-          retries: "{{ item['ansible_facts']['instance_conf_dict']['ssh_timeout'] | default(default_ssh_timeout) }}"
+        - name: SSH test
+          block:
+            - name: Check ssh access test
+              async_status:
+                jid: "{{ async_result_item.ansible_job_id }}"
+              loop: "{{ ssh_reg.results }}"
+              loop_control:
+                loop_var: "async_result_item"
+              register: async_poll_results
+              until: async_poll_results.finished
+              delay: 1
+              retries: "{{ item['ansible_facts']['instance_conf_dict']['ssh_timeout'] | default(default_ssh_timeout) }}"
+      rescue:
+        - name: Failed to get ssh
+          k8s_info:
+            kind: "{{ item }}"
+            api_version: kubevirt.io/v1alpha3
+            namespace: "{{ item.namespace | default(default_namespace) }}"
+          with_items:
+            - Service
+            - VirtualMachine
+            - VirtualMachineInstance
+          register: vm_info
+
+        - name: Failed to get running VM - Dump Service, VM and VMI
+          debug:
+            var: dump_var
+          vars:
+            dump_var: "{{ item }}"
+          loop: "{{ vm_info.results }}"
+          failed_when: true
 
     - name: Dump instance config
       copy:

--- a/molecule_kubevirt/playbooks/destroy.yml
+++ b/molecule_kubevirt/playbooks/destroy.yml
@@ -6,10 +6,9 @@
   no_log: "{{ molecule_no_log }}"
   tasks:
     - name: Delete VM
-      community.kubevirt.kubevirt_vm:
+      k8s:
         state: absent
-        wait: true
-        wait_timeout: 180
+        kind: VirtualMachine
         name: "{{ item.name }}"
         namespace: "{{ item.namespace | default('default') }}"
       loop: "{{ molecule_yml.platforms }}"

--- a/tox.ini
+++ b/tox.ini
@@ -38,9 +38,10 @@ setenv =
     MOLECULE_NO_LOG=0
 deps =
     py{36,37,38,39}-{ansible_2}: ansible>=2.10,<3.0
-    py{36,37,38,39}-{ansible_2}: openshift>=0.11,<0.12
+    # https://github.com/ansible/ansible/issues/72769#issuecomment-739176288
+    py{36,37,38,39}-{ansible_2}: kubernetes==11.*
+    py{36,37,38,39}-{ansible_2}: openshift==0.11.*
     py{36,37,38,39}-{ansible_2}: jmespath>=0.10.0
-    py{36,37,38,39}-{ansible_2}: kubernetes>=11,<12
     py{36,37,38,39}-{ansible_2}: molecule[test]
 
     py{36,37,38,39}-{ansible_3}: ansible>=3.0,<4.0
@@ -53,8 +54,6 @@ extras =
     lint
     test
 commands =
-    py{36,37,38,39}-{ansible_2}: ansible-galaxy install git+https://github.com/ansible-collections/community.general.git
-
     # failsafe as pip may install incompatible dependencies
     pip check
     # failsafe for preventing changes that may break pytest collection


### PR DESCRIPTION
remove community.kubevirt which is going to be deprecated in favor of core.k8s: 
 * implement k8s VM create and delete (no more async)
 * remove support of  `headless`   `hugepage_size`   `cpu_shares`  `ephemeral` for no current use-case reason
 * add  `autoattachGraphicsDevice` and mem/cpu limits and request 
 * refactor debug output in case of ssh failure
