### PR TITLE
enable VM customisation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -67,9 +67,7 @@ Follow KubeVirt guides for `kind <https://kubevirt.io/quickstart_kind/>`_, `mink
 SSH access
 ==========
 
-By default, the driver connects onto ssh via VirtualMachineInstance Pod ip.
-
-If molecule runs outside of the target Kubernetes cluster, a route to Pods must be defined:
+By default, the driver connects onto ssh via VirtualMachineInstance Pod ip and molecule needs to be able to ssh directly to Pod ip:
 
 * if running local Kubernetes with kind:
 
@@ -115,7 +113,7 @@ Default SSH Service is ClusterIP and a static clusterIP can be set:
     type: ClusterIP
     clusterIP: 10.96.102.231
 
-If molecule runs outside of the target Kubernetes cluster, a route to Services must be defined:
+Molecule then needs to be able to ssh on the ClusterIP ip:
 
 * if running local Kubernetes with Kind:
 

--- a/README.rst
+++ b/README.rst
@@ -116,6 +116,45 @@ NodePort can be set. Static nodePort can be defined, also host target for port c
     nodePort_host: localhost
 
 
+Virtual machines customization
+==============================
+
+Virtual machines can be customized using `domain`, `volumes`, `networks` and `user_data`.
+
+Since the driver already sets some values for molecule to start VMs with no customization, values set in those fields will be merged with default configuration.
+
+
+Disk example
+------------
+
+Here is an example on how to customize disks. Please note:
+
+* user_data is an example for Debian-11; other systems may have different disk name than /dev/vdxxx
+* since the driver creates one disk for OS, plus one disk for cloud-config, additional disk is third known disk (and gets *'c'* index)
+
+.. code-block:: yaml
+
+    domain:
+      devices:
+        disks:
+          - name: emptydisk
+            disk:
+              bus: virtio
+    volumes:
+      - name: emptydisk
+        emptyDisk:
+          capacity: 2Gi
+
+    user_data: |-
+      mounts:
+       - [ /dev/vdc, /var/lib/software, "auto", "defaults,nofail", "0", "0" ]
+      fs_setup:
+        - label: data_disk
+          filesystem: 'ext4'
+          device: /dev/vdc
+          overwrite: true
+
+
 Run from inside Kubernetes cluster
 ==================================
 

--- a/molecule_kubevirt/driver.py
+++ b/molecule_kubevirt/driver.py
@@ -59,16 +59,16 @@ class KubeVirt(Driver):
             memory_limit: memory
             cpu_limit: (omit)
             image: quay.io/kubevirt/fedora-cloud-container-disk-demo:latest
+            annotations: {}
             ssh_service:
                 type: ClusterIP
                 clusterIP: {}
                 nodePort: {}
                 nodePort_host: localhost
-            domain: {}
             volumes: []
             networks: []
-            user_data: {}
-
+            domain: {} # domain is merged with default
+            user_data: {} # user data cloud-config is merged with default
     Image MUST be accessible on Kubernetes workers running Kubevirt. This driver
     provides no service for building images. Solutions using CDI may be found in
     later version .

--- a/molecule_kubevirt/driver.py
+++ b/molecule_kubevirt/driver.py
@@ -58,12 +58,16 @@ class KubeVirt(Driver):
             cpu_request: (omit)
             memory_limit: memory
             cpu_limit: (omit)
-            image: image_name:tag
-        ssh_service:
-            type: ClusterIP
-            clusterIP: {}
-            nodePort: {}
-            nodePort_host: localhost
+            image: quay.io/kubevirt/fedora-cloud-container-disk-demo:latest
+            ssh_service:
+                type: ClusterIP
+                clusterIP: {}
+                nodePort: {}
+                nodePort_host: localhost
+            domain: {}
+            volumes: []
+            networks: []
+            user_data: {}
 
     Image MUST be accessible on Kubernetes workers running Kubevirt. This driver
     provides no service for building images. Solutions using CDI may be found in

--- a/molecule_kubevirt/playbooks/create.yml
+++ b/molecule_kubevirt/playbooks/create.yml
@@ -188,7 +188,7 @@
         name: "{{ item.item.name }}"
         instance: "{{ item.resources[0] | default({}) }}"
       loop: "{{ virtual_machine_info.results }}"
-      loop_control: 
+      loop_control:
         label: "{{ item.item.name }}"
       when: "item.ssh_service is not defined"
 
@@ -204,16 +204,14 @@
               identity_file: "{{ molecule_ephemeral_directory }}/identity_{{ item.name }}"
           vars:
             vmi: "{{ virtual_machine_info.results | selectattr('item.name','==',item.name) | first }}"
-            # FIXME: NodePort must default endpoint to nodePort if node endpoint specified 
-            # Also: should get a 'local node port' for nodePort kind usage for example 
             ssh_service_address: >-
-              {%- set svc_ep = item.ssh_service.type | default(None) -%}
-              {%- if not svc_ep -%}
+              {%- set svc_type = item.ssh_service.type | default(None) -%}
+              {%- if not svc_type -%}
                 {{ ((vmi['resources'] |first)['status']['interfaces'] | first)['ipAddress'] }}
-              {%- elif svc_ep == 'NodePort' -%}
+              {%- elif svc_type == 'NodePort' -%}
                 {{ item.ssh_service.nodePort_host | default('localhost') }}:
                 {{- ((node_port_services.results | selectattr('item.name','==',item.name) | first)['result']['spec']['ports'] | first)['nodePort'] }}
-              {%- elif svc_ep == 'ClusterIP' -%}
+              {%- elif svc_type == 'ClusterIP' -%}
                 {{ (cluster_ip_services.results | selectattr('item.name','==',item.name) | first)['result']['spec']['clusterIP'] }}
               {%- endif -%}
           register: instance_config_dict

--- a/molecule_kubevirt/playbooks/create.yml
+++ b/molecule_kubevirt/playbooks/create.yml
@@ -28,25 +28,30 @@
         label: "{{ item.name }}"
 
     - name: Create cloud init with ssh identity for molecule user
+      vars:
+        user_data: |-
+          {{ item.user_data | default({}) | from_yaml | combine(default_user_data | from_yaml, recursive=True, list_merge='append') }}
+        default_user_data: |-
+          users:
+            - name: {{ item.user_name | default(default_user_name) }}
+              sudo: ALL=(ALL) NOPASSWD:ALL
+              plain_text_passwd: molecule
+              lock_passwd: false
+              ssh_authorized_keys:
+                - {{ lookup('file', ssh_key_path + '.pub' ) }}
       k8s:
         state: present
         definition:
           apiVersion: v1
           kind: Secret
           metadata:
-            name: "{{ item.name }}-cloud-init"
+            name: "{{ item.name }}"
             namespace: "{{ item.namespace | default(default_namespace) }}"
           type: Opaque
           stringData:
             userdata: |-
               #cloud-config
-              users:
-                - name: {{ item.user_name | default(default_user_name) }}
-                  sudo: ALL=(ALL) NOPASSWD:ALL
-                  plain_text_passwd: molecule
-                  lock_passwd: false
-                  ssh_authorized_keys:
-                    - {{ lookup('file', ssh_key_path + '.pub' ) }}
+              {{ user_data | to_nice_yaml }}
       loop: "{{ molecule_yml.platforms  }}"
       loop_control:
         label: "{{ item.name }}"
@@ -54,7 +59,36 @@
     - name: Create virtual machines
       vars:
         container_disk_name: "{{ item.name }}"
-
+        domain:
+          devices:
+            autoattachGraphicsDevice: "{{ item.autoattachGraphicsDevice | default(false) }}"
+            disks:
+              - disk:
+                  bus: virtio
+                name: "{{ container_disk_name }}"
+              - disk:
+                  bus: virtio
+                name: ansiblecloudinitdisk
+          machine:
+            type: "{{ item.machine_type | default(default_vm_machine_type) }}"
+          resources:
+            requests:
+              memory: "{{ item.memory_request | default(item.memoy) | default(default_vm_memory) }}"
+              cpu: "{{ item.cpu_request | default(item.cpu) | default(omit) }}"
+            limits:
+              memory: "{{ item.memory_limit | default(item.memoy) | default(default_vm_memory) }}"
+              cpu: "{{ item.cpu_limit | default(item.cpu) | default(omit) }}"
+        networks: "{{ item.networks | default([]) }}"
+        volumes:
+          - containerDisk:
+              image: "{{ item.image | default(default_vm_disk_image) }}"
+              path: "{{ item.image_path | default(omit) }}"
+              imagePullPolicy: "{{ item.image_pull_policy | default('IfNotPresent') }}"
+            name: "{{ container_disk_name }}"
+          - cloudInitNoCloud:
+              secretRef:
+                name: "{{ item.name }}"
+            name: ansiblecloudinitdisk
       k8s:
         state: present
         definition:
@@ -67,46 +101,13 @@
             running: true
             template:
               metadata:
+                annotations: "{{ item.annotations | default({}) }}"
                 labels:
                   vm.cnv.io/name: "{{ item.name }}"
               spec:
-                domain:
-                  devices:
-                    autoattachGraphicsDevice: "{{ item.autoattachGraphicsDevice | default(false) }}"
-                    disks:
-                      - disk:
-                          bus: virtio
-                        name: "{{ container_disk_name }}"
-                      - disk:
-                          bus: virtio
-                        name: ansiblecloudinitdisk
-                    interfaces:
-                      - masquerade: {}
-                        name: default
-                        ports:
-                          - port: 22
-                  machine:
-                    type: "{{ item.machine_type | default(default_vm_machine_type) }}"
-                  resources:
-                    requests:
-                      memory: "{{ item.memory_request | default(item.memoy) | default(default_vm_memory) }}"
-                      cpu: "{{ item.cpu_request | default(item.cpu) | default(omit) }}"
-                    limits:
-                      memory: "{{ item.memory_limit | default(item.memoy) | default(default_vm_memory) }}"
-                      cpu: "{{ item.cpu_limit | default(item.cpu) | default(omit) }}"
-                networks:
-                  - name: default
-                    pod: {}
-                volumes:
-                  - containerDisk:
-                      image: "{{ item.image | default(default_vm_disk_image) }}"
-                      path: "{{ item.image_path | default(omit) }}"
-                      imagePullPolicy: "{{ item.image_pull_policy | default('IfNotPresent') }}"
-                    name: "{{ container_disk_name }}"
-                  - cloudInitNoCloud:
-                      secretRef:
-                        name: "{{ item.name }}-cloud-init"
-                    name: ansiblecloudinitdisk
+                domain: "{{ item.domain | default({}) | combine(domain, recursive=True, list_merge='prepend') }}"
+                networks: "{{ networks }}"
+                volumes: "{{ volumes + (item.volumes | default([])) }}"
       loop: "{{ molecule_yml.platforms }}"
       loop_control:
         label: "{{ item.name }}"

--- a/molecule_kubevirt/playbooks/create.yml
+++ b/molecule_kubevirt/playbooks/create.yml
@@ -30,7 +30,7 @@
     - name: Create cloud init with ssh identity for molecule user
       vars:
         user_data: |-
-          {{ item.user_data | default({}) | from_yaml | combine(default_user_data | from_yaml, recursive=True, list_merge='append') }}
+          {{ item.user_data | default({}) | from_yaml | combine(default_user_data | from_yaml, recursive=True, list_merge='prepend') }}
         default_user_data: |-
           users:
             - name: {{ item.user_name | default(default_user_name) }}

--- a/molecule_kubevirt/playbooks/create.yml
+++ b/molecule_kubevirt/playbooks/create.yml
@@ -113,75 +113,87 @@
         label: "{{ item.name }}"
       register: poll_reg
 
-    - name: Create ssh NodePort Kubernetes Services
-      when: "item.ssh_service.type | default(default_ssh_service_type) == 'NodePort'"
-      k8s:
-        state: present
-        definition:
-          apiVersion: v1
-          kind: Service
-          metadata:
-            name: "{{ item.name }}"
-            namespace: "{{ item.namespace | default(default_namespace) }}"
-          spec: "{{ spec | from_yaml }}"
-      register: node_port_services
-      loop: "{{ molecule_yml.platforms  }}"
-      loop_control:
-        label: "{{ item.name }}"
-      # workaround https://stackoverflow.com/questions/63961938/ansible-variable-conversion-to-int-is-ignored
-      vars:
-        spec: |-
-          ports:
-            - port: 22
-              protocol: TCP
-              targetPort: 22
-              {%- if item.ssh_service.nodePort | default(None) +%}
-              nodePort: {{ item.ssh_service.nodePort | int }}
-              {%- endif +%}
-          selector:
-            vm.cnv.io/name: "{{ item.name }}"
-          type: NodePort
+    - name: Deal with ssh services
+      when: "item.ssh_service | default(None)"
+      block:
+        - name: Create ssh NodePort Kubernetes Services
+          when: "item.ssh_service.type | default(default_ssh_service_type) == 'NodePort'"
+          k8s:
+            state: present
+            definition:
+              apiVersion: v1
+              kind: Service
+              metadata:
+                name: "{{ item.name }}"
+                namespace: "{{ item.namespace | default(default_namespace) }}"
+              spec: "{{ spec | from_yaml }}"
+          register: node_port_services
+          loop: "{{ molecule_yml.platforms  }}"
+          loop_control:
+            label: "{{ item.name }}"
+          # workaround https://stackoverflow.com/questions/63961938/ansible-variable-conversion-to-int-is-ignored
+          vars:
+            spec: |-
+              ports:
+                - port: 22
+                  protocol: TCP
+                  targetPort: 22
+                  {%- if item.ssh_service.nodePort | default(None) +%}
+                  nodePort: {{ item.ssh_service.nodePort | int }}
+                  {%- endif +%}
+              selector:
+                vm.cnv.io/name: "{{ item.name }}"
+              type: NodePort
 
-    - name: Create ssh ClusterIP Kubernetes Services
-      when: "item.ssh_service.type | default(default_ssh_service_type) == 'ClusterIP'"
-      k8s:
-        state: present
-        definition:
-          apiVersion: v1
-          kind: Service
-          metadata:
-            name: "{{ item.name }}"
-            namespace: "{{ item.namespace | default(default_namespace) }}"
-          spec:
-            clusterIP: "{{ item.ssh_service.clusterIP | default(omit) }}"
-            ports:
-              - port: 22
-                protocol: TCP
-                targetPort: 22
-            selector:
-              vm.cnv.io/name: "{{ item.name }}"
-            type: ClusterIP
-      register: cluster_ip_services
-      loop: "{{ molecule_yml.platforms  }}"
-      loop_control:
-        label: "{{ item.name }}"
+        - name: Create ssh ClusterIP Kubernetes Services
+          when: "item.ssh_service.type | default(default_ssh_service_type) == 'ClusterIP'"
+          k8s:
+            state: present
+            definition:
+              apiVersion: v1
+              kind: Service
+              metadata:
+                name: "{{ item.name }}"
+                namespace: "{{ item.namespace | default(default_namespace) }}"
+              spec:
+                clusterIP: "{{ item.ssh_service.clusterIP | default(omit) }}"
+                ports:
+                  - port: 22
+                    protocol: TCP
+                    targetPort: 22
+                selector:
+                  vm.cnv.io/name: "{{ item.name }}"
+                type: ClusterIP
+          register: cluster_ip_services
+          loop: "{{ molecule_yml.platforms  }}"
+          loop_control:
+            label: "{{ item.name }}"
+
+    - name: Get ip for VirtualMachineInstance
+      k8s_info:
+        kind: VirtualMachineInstance
+        namespace: "{{ item.namespace | default(default_namespace) }}"
+        name: "{{ item.name }}"
+      loop: "{{ molecule_yml.platforms }}"
+      register: virtual_machine_info
+      retries: 3
+      until: "virtual_machine_info.resources[0].status.interfaces[0].ipAddress | default(None)"
+      when: "item.ssh_service is not defined"
+
+    - name: Get Virtual Machine ip, indexed by name
+      set_fact:
+        virtual_machine_instance: >-
+          {{ virtual_machine_instance | default({}) | combine ({name: instance}) }}
+      vars:
+        name: "{{ item.item.name }}"
+        instance: "{{ item.resources[0] | default({}) }}"
+      loop: "{{ virtual_machine_info.results }}"
+      loop_control: 
+        label: "{{ item.item.name }}"
+      when: "item.ssh_service is not defined"
 
     - name: SSH check block
       block:
-        - name: Get ssh services info, indexed by service name
-          set_fact:
-            service_instance: >-
-              {{ service_instance|default({}) | combine({svc_name: svc_spec}) }}
-          loop: "{{ loop_services | flatten }}"
-          loop_control:
-            label: "{{ {svc_name: svc_spec } }}"
-          vars:
-            loop_services:
-              - "{{ cluster_ip_services.results | rejectattr('skipped', 'true') }}"
-              - "{{ node_port_services.results| rejectattr('skipped', 'true') }}"
-            svc_name: "{{ item.result.metadata.name }}"
-            svc_spec: "{{ item.result.spec }}"
-
         - name: Populate instance config dict
           set_fact:
             instance_conf_dict:
@@ -191,13 +203,18 @@
               port: "22"
               identity_file: "{{ molecule_ephemeral_directory }}/identity_{{ item.name }}"
           vars:
-            # set target ssh address regarding platforms configuration
+            vmi: "{{ virtual_machine_info.results | selectattr('item.name','==',item.name) | first }}"
+            # FIXME: NodePort must default endpoint to nodePort if node endpoint specified 
+            # Also: should get a 'local node port' for nodePort kind usage for example 
             ssh_service_address: >-
-              {%- set svc_ep = item.ssh_service.type | default('ClusterIP') -%}
-              {%- if svc_ep == 'NodePort' -%}
-              {{ item.ssh_service.nodePort_host | default('localhost') }}:{{ service_instance[item.name].ports[item.ssh_service.nodePort_index | default(0)].nodePort }}
+              {%- set svc_ep = item.ssh_service.type | default(None) -%}
+              {%- if not svc_ep -%}
+                {{ ((vmi['resources'] |first)['status']['interfaces'] | first)['ipAddress'] }}
+              {%- elif svc_ep == 'NodePort' -%}
+                {{ item.ssh_service.nodePort_host | default('localhost') }}:
+                {{- ((node_port_services.results | selectattr('item.name','==',item.name) | first)['result']['spec']['ports'] | first)['nodePort'] }}
               {%- elif svc_ep == 'ClusterIP' -%}
-              {{ service_instance[item.name].clusterIP }}
+                {{ (cluster_ip_services.results | selectattr('item.name','==',item.name) | first)['result']['spec']['clusterIP'] }}
               {%- endif -%}
           register: instance_config_dict
           loop: "{{ molecule_yml.platforms }}"
@@ -222,17 +239,15 @@
           register: ssh_reg
 
         - name: SSH test
-          block:
-            - name: Check ssh access test
-              async_status:
-                jid: "{{ async_result_item.ansible_job_id }}"
-              loop: "{{ ssh_reg.results }}"
-              loop_control:
-                loop_var: "async_result_item"
-              register: async_poll_results
-              until: async_poll_results.finished
-              delay: 1
-              retries: "{{ item['ansible_facts']['instance_conf_dict']['ssh_timeout'] | default(default_ssh_timeout) }}"
+          async_status:
+            jid: "{{ async_result_item.ansible_job_id }}"
+          loop: "{{ ssh_reg.results }}"
+          loop_control:
+            loop_var: "async_result_item"
+          register: async_poll_results
+          until: async_poll_results.finished
+          delay: 1
+          retries: "{{ item['ansible_facts']['instance_conf_dict']['ssh_timeout'] | default(default_ssh_timeout) }}"
       rescue:
         - name: Failed to get ssh
           k8s_info:

--- a/setup.cfg
+++ b/setup.cfg
@@ -65,9 +65,8 @@ setup_requires =
 # These are required in actual runtime:
 install_requires =
     molecule >= 3.2.0a0
-    openshift >= 0.10.3
-
-
+    openshift < 0.12.0
+    kubernetes < 12.0.0
 [options.extras_require]
 docs =
     simplejson


### PR DESCRIPTION
Network: no more default networks in VM.

Ssh:  Default ssh_service now set to None and therefore VM instance ip is fetched and use as ssh connection string. 

New params availables for superset VMs:
* `domain` dictionary is merged with default domain 
* `user_data` cloud-config is appened to default
* `volumes` are appended to defaults
* `networks`default omit
* `annotations` default omit

Removed ssh_service.endpoint which had no known use-case.

Add doc. 
