### PR TITLE
use newer fedora image as default

### DIFF
--- a/molecule_kubevirt/playbooks/create.yml
+++ b/molecule_kubevirt/playbooks/create.yml
@@ -14,7 +14,7 @@
     default_vm_memory: "2Gi"
     default_vm_machine_type: "q35"
     default_vm_disk_image: "quay.io/containerdisks/fedora:latest"
-    default_ssh_timeout: 300
+    default_ssh_timeout: 600
     default_ssh_delay: 1
     default_pod_ip_retries: 60
     default_pod_ip_delay: 1

--- a/molecule_kubevirt/playbooks/create.yml
+++ b/molecule_kubevirt/playbooks/create.yml
@@ -13,7 +13,7 @@
         - ALL=(ALL) NOPASSWD:ALL
     default_vm_memory: "2Gi"
     default_vm_machine_type: "q35"
-    default_vm_disk_image: "quay.io/kubevirt/fedora-cloud-container-disk-demo:v0.36.5"
+    default_vm_disk_image: "quay.io/containerdisks/fedora:latest"
     default_ssh_timeout: 300
     default_ssh_delay: 1
     default_pod_ip_retries: 60

--- a/molecule_kubevirt/playbooks/create.yml
+++ b/molecule_kubevirt/playbooks/create.yml
@@ -13,7 +13,7 @@
         - ALL=(ALL) NOPASSWD:ALL
     default_vm_memory: "2Gi"
     default_vm_machine_type: "q35"
-    default_vm_disk_image: "quay.io/containerdisks/fedora:latest"
+    default_vm_disk_image: "quay.io/containerdisks/fedora:36"
     default_ssh_timeout: 600
     default_ssh_delay: 1
     default_pod_ip_retries: 60

--- a/molecule_kubevirt/playbooks/create.yml
+++ b/molecule_kubevirt/playbooks/create.yml
@@ -13,7 +13,7 @@
         - ALL=(ALL) NOPASSWD:ALL
     default_vm_memory: "2Gi"
     default_vm_machine_type: "q35"
-    default_vm_disk_image: "quay.io/kubevirt/fedora-cloud-container-disk-demo"
+    default_vm_disk_image: "quay.io/kubevirt/fedora-cloud-container-disk-demo:v0.36.5"
     default_ssh_timeout: 300
     default_ssh_delay: 1
     default_pod_ip_retries: 60


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

At the start this PR intended to test if a some newer fedora image would make GH actions green again but no. Still may be relevant to change this image to a newer one. 


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
