### PR TITLE
add validate_certs option to create and destroy molecule playbooks

### DIFF
--- a/molecule_kubevirt/playbooks/create.yml
+++ b/molecule_kubevirt/playbooks/create.yml
@@ -37,6 +37,7 @@
       name: default
       model: virtio
     ssh_key_path: "{{ molecule_ephemeral_directory }}/identity_{{ item.name }}"
+    default_validate_certs: true
   tasks:
     - name: Create ssh key pair
       openssh_keypair:
@@ -61,6 +62,7 @@
         user_data: |-
           {{ item.user_data | default({}) | from_yaml | combine(default_user_data | from_yaml, recursive=True, list_merge='prepend') }}
       k8s:
+        validate_certs: "{{ item.validate_certs | default(default_validate_certs) }}"
         state: present
         definition:
           apiVersion: v1
@@ -151,6 +153,7 @@
             tolerations: {{ item.tolerations | default(omit) }}
       # Create VM
       k8s:
+        validate_certs: "{{ item.validate_certs | default(default_validate_certs) }}"
         state: present
         definition:
           apiVersion: kubevirt.io/v1
@@ -179,6 +182,7 @@
         - name: Create ssh NodePort Kubernetes Services
           when: "item.ssh_service.type | default(default_ssh_service_type) == 'NodePort'"
           k8s:
+            validate_certs: "{{ item.validate_certs | default(default_validate_certs) }}"
             state: present
             definition:
               apiVersion: v1
@@ -208,6 +212,7 @@
         - name: Create ssh ClusterIP Kubernetes Services
           when: "item.ssh_service.type | default(default_ssh_service_type) == 'ClusterIP'"
           k8s:
+            validate_certs: "{{ item.validate_certs | default(default_validate_certs) }}"
             state: present
             definition:
               apiVersion: v1
@@ -231,6 +236,7 @@
 
     - name: Get ip for VirtualMachineInstance for ssh access
       k8s_info:
+        validate_certs: "{{ item.validate_certs | default(default_validate_certs) }}"
         kind: VirtualMachineInstance
         namespace: "{{ item.namespace | default(default_namespace) }}"
         name: "{{ item.name }}"

--- a/molecule_kubevirt/playbooks/destroy.yml
+++ b/molecule_kubevirt/playbooks/destroy.yml
@@ -4,9 +4,12 @@
   connection: local
   gather_facts: false
   no_log: "{{ molecule_no_log }}"
+  vars:
+    default_validate_certs: true
   tasks:
     - name: Delete VM
       k8s:
+        validate_certs: "{{ item.validate_certs | default(default_validate_certs) }}"
         state: absent
         kind: VirtualMachine
         name: "{{ item.name }}"
@@ -17,6 +20,7 @@
 
     - name: Delete cloud init
       k8s:
+        validate_certs: "{{ item.validate_certs | default(default_validate_certs) }}"
         state: absent
         kind: Secret
         name: "{{ item.name }}"
@@ -27,6 +31,7 @@
 
     - name: Delete ssh service
       k8s:
+        validate_certs: "{{ item.validate_certs | default(default_validate_certs) }}"
         state: absent
         kind: Service
         name: "{{ item.name }}"


### PR DESCRIPTION
Hello,

I'm currently experimenting with the kubevirt_molecule driver in a staging OpenShift cluster. This cluster utilizes a self-signed digital certificate. Consequently, I would like the create/delete playbooks to have the ability to parameterize the `validate_certs` value. This parameter would allow me to choose whether to enable or disable TLS verification, with the default setting being enabled.

The purpose of this pull request is to add parameterization for the `validate_certs` value in the create/delete playbooks, with TLS verification set to true by default.

Thank you in advance!